### PR TITLE
Add a new error handling that preserves neutral strings

### DIFF
--- a/Gu.Localization.Tests/TranslatorGenericTests.cs
+++ b/Gu.Localization.Tests/TranslatorGenericTests.cs
@@ -63,6 +63,25 @@ namespace Gu.Localization.Tests
             Assert.AreEqual(expected, actual);
         }
 
+        [TestCase(null, "sv", "key == null", ErrorHandling.ReturnErrorInfoPreserveNeutral)]
+        [TestCase("Missing", "sv", "!Missing!", ErrorHandling.ReturnErrorInfoPreserveNeutral)]
+        [TestCase(nameof(Properties.Resources.EnglishOnly), "sv", "_EnglishOnly_", ErrorHandling.ReturnErrorInfoPreserveNeutral)]
+        [TestCase(nameof(Properties.Resources.EnglishOnly), "it", "~EnglishOnly~", ErrorHandling.ReturnErrorInfoPreserveNeutral)]
+        [TestCase(nameof(Properties.Resources.AllLanguages), "it", "So neutral", ErrorHandling.ReturnErrorInfoPreserveNeutral)]
+        public void WithNeutral(string key, string culture, string expected, ErrorHandling errorHandling)
+        {
+            Translator.CurrentCulture = culture == null
+                                            ? CultureInfo.InvariantCulture
+                                            : CultureInfo.GetCultureInfo(culture);
+            Translator.ErrorHandling = ErrorHandling.Throw;
+            var actual = Translator<Properties.Resources>.Translate(key, errorHandling);
+            Assert.AreEqual(expected, actual);
+
+            Translator.ErrorHandling = errorHandling;
+            actual = Translator<Properties.Resources>.Translate(key);
+            Assert.AreEqual(expected, actual);
+        }
+
         [TestCase("Missing", null, "The resourcemanager Gu.Localization.Tests.Properties.Resources does not have the key: Missing\r\nParameter name: key")]
         [TestCase("Missing", "sv", "The resourcemanager Gu.Localization.Tests.Properties.Resources does not have the key: Missing\r\nParameter name: key")]
         [TestCase(nameof(Properties.Resources.EnglishOnly), "sv", "The resourcemanager Gu.Localization.Tests.Properties.Resources does not have a translation for the key: EnglishOnly for the culture: sv\r\nParameter name: key")]

--- a/Gu.Localization/ErrorHandling.cs
+++ b/Gu.Localization/ErrorHandling.cs
@@ -10,6 +10,9 @@
         Throw,
 
         /// <summary>Returns information about the error in the result.</summary>
-        ReturnErrorInfo
+        ReturnErrorInfo,
+
+        /// <summary>Returns information about the error in the result but leaves neutral strings intact</summary>
+        ReturnErrorInfoPreserveNeutral
     }
 }

--- a/Gu.Localization/Translator.cs
+++ b/Gu.Localization/Translator.cs
@@ -131,6 +131,11 @@
             ErrorHandling errorHandling,
             out string result)
         {
+            if (errorHandling == ErrorHandling.Default)
+            {
+                errorHandling = ErrorHandling;
+            }
+
             var shouldThrow = ShouldThrow(errorHandling);
             if (resourceManager == null)
             {
@@ -178,6 +183,12 @@
                     var trnslated = resourceManager.GetString(key, culture);
                     if (!string.IsNullOrEmpty(trnslated))
                     {
+                        if (errorHandling == ErrorHandling.ReturnErrorInfoPreserveNeutral)
+                        {
+                            result = trnslated;
+                            return true;
+                        }
+
                         result = string.Format(Properties.Resources.MissingCultureFormat, trnslated);
                         return false;
                     }
@@ -226,7 +237,10 @@
                 errorHandling = ErrorHandling;
             }
 
-            var shouldThrow = errorHandling != ErrorHandling.ReturnErrorInfo;
+            var shouldThrow =
+                errorHandling != ErrorHandling.ReturnErrorInfo &&
+                errorHandling != ErrorHandling.ReturnErrorInfoPreserveNeutral;
+
             return shouldThrow;
         }
 


### PR DESCRIPTION
ErrorHandling was enhanced with a new ReturnErrorInfoPreserveNeutral case
that makes the translator return neutral language strings without error
info.

This closes issue #11

Signed-off-by: Axel Gembe <axel@gembe.net>